### PR TITLE
Fix runway log

### DIFF
--- a/src/aviao.py
+++ b/src/aviao.py
@@ -115,7 +115,8 @@ def aviaoProc(env, nome, aeroporto):
               (nome, env.now))
 
     # LOG
-    log_simulacao['pista'] = pista['id']
+    # registra a identificação da pista utilizada na decolagem
+    log_simulacao['pista de decolagem'] = pista['id']
     yield aeroporto.pista.put(pista)  # libera a pista
 
     # Registrar métricas


### PR DESCRIPTION
## Summary
- fix wrong log key for decolagem runway

## Testing
- `python -m py_compile src/aviao.py src/aeroporto.py src/globals.py src/metricas.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6850124426d48330b169585e89d26dc9