### PR TITLE
Fix tempo_medio_fila_fingers typo

### DIFF
--- a/src/metricas.py
+++ b/src/metricas.py
@@ -70,7 +70,7 @@ def tempo_medio_fila_pistas(data, qtd_avioes):
     print('Tempo médio de espera na fila para acesso a pista: %.2f min' % avg)
 
 
-def tempo_medio_fila_finges(data, qtd_avioes):
+def tempo_medio_fila_fingers(data, qtd_avioes):
     s = 0
     for d in data:
         s += time_dif(d['fila de desembarque'])
@@ -115,7 +115,7 @@ def log_simulacao(data):
 
     print('')
     tempo_medio_fila_pistas(data, qtd_avioes)
-    tempo_medio_fila_finges(data, qtd_avioes)
+    tempo_medio_fila_fingers(data, qtd_avioes)
     tempo_medio_fila_bomba(data)
 
     pass


### PR DESCRIPTION
## Summary
- rename `tempo_medio_fila_finges` to `tempo_medio_fila_fingers`
- update `log_simulacao` to call the renamed function

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850134312b483308736d423bceafe72