### PR TITLE
Fix pluralization typo in docs

### DIFF
--- a/docs/carga-alta-pistas-2.txt
+++ b/docs/carga-alta-pistas-2.txt
@@ -1,6 +1,6 @@
 Os parâmetros para que a simulação ocorra com carga alta:
 
-- 2 pista e 2 fingers;
+- 2 pistas e 2 fingers;
 - Tempo de pouso = 7 min;
 - Tempo de decolagem = 8 min;
 - Tempo de embarque/desembarque = 20 min;


### PR DESCRIPTION
## Summary
- fix pluralization for 2-runway case in docs/carga-alta-pistas-2.txt

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850136baa488330b7facb30885bcdc4