### PR TITLE
Remove redundant pass statements

### DIFF
--- a/src/aeroporto.py
+++ b/src/aeroporto.py
@@ -31,7 +31,6 @@ class Aeroporto:
 
         # setup para iniciar filas
         self.init_queue(qtd_pistas, qtd_fingers, qtd_bombas)
-        pass
 
     def init_queue(self, qtd_pistas, qtd_fingers, qtd_bombas):
         for i in range(qtd_pistas):
@@ -43,11 +42,9 @@ class Aeroporto:
         for i in range(qtd_bombas):
             self.bomba.put({'id': i})
 
-        pass
 
     def registrar_metrica(self, entry):
         self.log_metricas.append(entry)
-        pass
 
     def procedimento(self, aviao, proc):
         global VERBOSE_SERV
@@ -72,6 +69,4 @@ class Aeroporto:
         yield self.env.timeout(tempo)
         if VERBOSE_SERV:
             print('Avião %s em procedimento de %s.' % (aviao, proc))
-        pass
 
-    pass

--- a/src/aviao.py
+++ b/src/aviao.py
@@ -120,7 +120,6 @@ def aviaoProc(env, nome, aeroporto):
 
     # Registrar métricas
     aeroporto.registrar_metrica(log_simulacao)
-    pass
 
 
 def configura_aeroporto(env, aeroporto, tempo_spawn, qtd_avioes, qtd_pistas, qtd_fingers, qtd_bombas):
@@ -140,4 +139,3 @@ def configura_aeroporto(env, aeroporto, tempo_spawn, qtd_avioes, qtd_pistas, qtd
         i += 1
         env.process(aviaoProc(env, 'Avião %d' % i, aeroporto))
 
-    pass

--- a/src/metricas.py
+++ b/src/metricas.py
@@ -118,4 +118,3 @@ def log_simulacao(data):
     tempo_medio_fila_finges(data, qtd_avioes)
     tempo_medio_fila_bomba(data)
 
-    pass


### PR DESCRIPTION
## Summary
- tidy up `Aeroporto`, `aviaoProc`, and metrics routines by removing redundant `pass` lines

## Testing
- `python3 -m py_compile src/*.py`
- `python3 main.py`

------
https://chatgpt.com/codex/tasks/task_e_68501513e75c8330b7b0d8e70b24aadf