### PR TITLE
Introduce logging with verbosity levels

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8-sig -*-
 
+import logging
 import simpy  # biblioteca de simulação
 from src.globals import *
 from src.aeroporto import Aeroporto
@@ -27,8 +28,19 @@ Scenario:
 
 if __name__ == '__main__':
 
+    level = logging.WARNING
+    if LOG_VERBOSE:
+        level = logging.INFO
+    if VERBOSE_SERV:
+        level = logging.DEBUG
+    logging.basicConfig(
+        level=level,
+        format='%(asctime)s - %(levelname)s - %(message)s'
+    )
+    logger = logging.getLogger(__name__)
+
     # Configurar e iniciar a simulação
-    print('Simulador Aeroporto')
+    logger.info('Simulador Aeroporto')
     random.seed(getSeed(RANDOM_SEED))   # semente do gerador de números aleatórios
     env = simpy.Environment()			# cria o environment do modelo
     

--- a/src/aeroporto.py
+++ b/src/aeroporto.py
@@ -1,8 +1,11 @@
 #!/usr/bin/python
 # -*- coding: utf-8-sig -*-
 
+import logging
 import simpy
 from src.globals import *
+
+logger = logging.getLogger(__name__)
 
 
 class Aeroporto:
@@ -50,7 +53,6 @@ class Aeroporto:
         pass
 
     def procedimento(self, aviao, proc):
-        global VERBOSE_SERV
 
         tempo = 0
         if proc == 'pousar':
@@ -70,8 +72,7 @@ class Aeroporto:
             tempo = TEMPO_DECOLAGEM
 
         yield self.env.timeout(tempo)
-        if VERBOSE_SERV:
-            print('Avião %s em procedimento de %s.' % (aviao, proc))
+        logger.debug('Avião %s em procedimento de %s.', aviao, proc)
         pass
 
     pass

--- a/src/aviao.py
+++ b/src/aviao.py
@@ -1,11 +1,14 @@
 #!/usr/bin/python
 # -*- coding: utf-8-sig -*-
 
+import logging
 import random
 import math
 from os import urandom
 
 from src.globals import *
+
+logger = logging.getLogger(__name__)
 
 
 def getSeed(num):
@@ -29,23 +32,18 @@ def aviaoProc(env, nome, aeroporto):
         'bomba de combustivel': None,
     }
 
-    global LOG_VERBOSE
-
-# ---------------- Pouso ----------------
+    # ---------------- Pouso ----------------
     # FILA
-    if LOG_VERBOSE:
-        print('%s em primeiro contato com o aeroporto às %.2f. Aguardando autorização de pouso.' % (
-            nome, env.now))
+    logger.info('%s em primeiro contato com o aeroporto às %.2f. Aguardando autorização de pouso.',
+                nome, env.now)
     log_simulacao['fila de pouso'].append(env.now)  # fila de pouso
     pista = yield aeroporto.pista.get()  # pista livre
     log_simulacao['fila de pouso'].append(env.now)  # fila de pouso
 
     # SERVIÇO
-    if LOG_VERBOSE:
-        print('%s chegou à pista de pouso. Pouso às %.2f.' % (nome, env.now))
+    logger.info('%s chegou à pista de pouso. Pouso às %.2f.', nome, env.now)
     yield env.process(aeroporto.procedimento(nome, 'pousar'))
-    if LOG_VERBOSE:
-        print('%s saiu da pista de pouso às %.2f.' % (nome, env.now))
+    logger.info('%s saiu da pista de pouso às %.2f.', nome, env.now)
 
     # LOG
     log_simulacao['pista de pouso'] = pista['id']
@@ -56,21 +54,18 @@ def aviaoProc(env, nome, aeroporto):
     combustivel = random.randint(0, 100)
     if combustivel <= 65:
         # FILA
-        if LOG_VERBOSE:
-            print('%s requisitou reabastecimento às %.2f. Nível do combustível: %i/100.' %
-                  (nome, env.now, combustivel))
+        logger.info('%s requisitou reabastecimento às %.2f. Nível do combustível: %i/100.',
+                    nome, env.now, combustivel)
         log_simulacao['fila de abastecimento'].append(env.now)
         bomba = yield aeroporto.bomba.get()  # bomba livre
         log_simulacao['fila de abastecimento'].append(env.now)
 
         # SERVIÇO
-        if LOG_VERBOSE:
-            print('%s chegou ao posto de abastecimento às %.2f. Abastecendo o tanque.' % (
-                nome, env.now))
+        logger.info('%s chegou ao posto de abastecimento às %.2f. Abastecendo o tanque.',
+                    nome, env.now)
         yield env.process(aeroporto.procedimento(nome, 'abastecer'))
-        if LOG_VERBOSE:
-            print('%s está de tanque cheio. Saiu do posto de abastecimento às %.2f.' % (
-                nome, env.now))
+        logger.info('%s está de tanque cheio. Saiu do posto de abastecimento às %.2f.',
+                    nome, env.now)
 
         # LOG
         log_simulacao['bomba de combustivel'] = bomba['id']
@@ -79,18 +74,15 @@ def aviaoProc(env, nome, aeroporto):
 # ---------------- Desembarque/Embarque	----------------
 
     # FILA
-    if LOG_VERBOSE:
-        print('%s dirigindo-se à área de desembarque às %.2f.' % (nome, env.now))
+    logger.info('%s dirigindo-se à área de desembarque às %.2f.', nome, env.now)
     log_simulacao['fila de desembarque'].append(env.now)
     finger = yield aeroporto.finger.get()  # finger livre
     log_simulacao['fila de desembarque'].append(env.now)
 
     # SERVIÇO
-    if LOG_VERBOSE:
-        print('%s iniciou o embarque às %.2f.' % (nome, env.now))
+    logger.info('%s iniciou o embarque às %.2f.', nome, env.now)
     yield env.process(aeroporto.procedimento(nome, 'embarcar'))
-    if LOG_VERBOSE:
-        print('%s encerrou o embarque às %.2f.' % (nome, env.now))
+    logger.info('%s encerrou o embarque às %.2f.', nome, env.now)
 
     # LOG
     log_simulacao['finger'] = finger['id']
@@ -99,20 +91,17 @@ def aviaoProc(env, nome, aeroporto):
 # ---------------- Decolagem ----------------
 
     # FILA
-    if LOG_VERBOSE:
-        print('%s dirigindo-se à pista de decolagem às %.2f.' % (nome, env.now))
+    logger.info('%s dirigindo-se à pista de decolagem às %.2f.', nome, env.now)
     log_simulacao['fila de decolagem'].append(env.now)
     pista = yield aeroporto.pista.get()  # pista livre
     log_simulacao['fila de decolagem'].append(env.now)
 
     # SERVIÇO
-    if LOG_VERBOSE:
-        print('%s chegou à pista de decolagem. Início da decolagem às %.2f.' %
-              (nome, env.now))
+    logger.info('%s chegou à pista de decolagem. Início da decolagem às %.2f.',
+                nome, env.now)
     yield env.process(aeroporto.procedimento(nome, 'decolar'))
-    if LOG_VERBOSE:
-        print('%s saiu da pista de pouso. Último contato feito às %.2f.' %
-              (nome, env.now))
+    logger.info('%s saiu da pista de pouso. Último contato feito às %.2f.',
+                nome, env.now)
 
     # LOG
     log_simulacao['pista'] = pista['id']


### PR DESCRIPTION
## Summary
- add logging setup in `main.py`
- replace `print` calls in `src/aviao.py` and `src/aeroporto.py` with logger usage
- drive logger level from `LOG_VERBOSE` and `VERBOSE_SERV`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py >/tmp/run.log && tail -n 5 /tmp/run.log`

------
https://chatgpt.com/codex/tasks/task_e_6850151bbea88330a2aad025fa23d9aa