### PR TITLE
Fix runway metric key

### DIFF
--- a/src/aviao.py
+++ b/src/aviao.py
@@ -115,7 +115,7 @@ def aviaoProc(env, nome, aeroporto):
               (nome, env.now))
 
     # LOG
-    log_simulacao['pista'] = pista['id']
+    log_simulacao['pista de decolagem'] = pista['id']
     yield aeroporto.pista.put(pista)  # libera a pista
 
     # Registrar métricas


### PR DESCRIPTION
## Summary
- store runway usage under `pista de decolagem` key when logging

## Testing
- `python -m py_compile src/aviao.py src/metricas.py src/aeroporto.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_685017a496a08330863361886222d709