### PR TITLE
Remove unused pass statements

### DIFF
--- a/src/aeroporto.py
+++ b/src/aeroporto.py
@@ -31,7 +31,6 @@ class Aeroporto:
 
         # setup para iniciar filas
         self.init_queue(qtd_pistas, qtd_fingers, qtd_bombas)
-        pass
 
     def init_queue(self, qtd_pistas, qtd_fingers, qtd_bombas):
         for i in range(qtd_pistas):
@@ -43,11 +42,8 @@ class Aeroporto:
         for i in range(qtd_bombas):
             self.bomba.put({'id': i})
 
-        pass
-
     def registrar_metrica(self, entry):
         self.log_metricas.append(entry)
-        pass
 
     def procedimento(self, aviao, proc):
         global VERBOSE_SERV
@@ -72,6 +68,3 @@ class Aeroporto:
         yield self.env.timeout(tempo)
         if VERBOSE_SERV:
             print('Avião %s em procedimento de %s.' % (aviao, proc))
-        pass
-
-    pass

--- a/src/aviao.py
+++ b/src/aviao.py
@@ -120,7 +120,6 @@ def aviaoProc(env, nome, aeroporto):
 
     # Registrar métricas
     aeroporto.registrar_metrica(log_simulacao)
-    pass
 
 
 def configura_aeroporto(env, aeroporto, tempo_spawn, qtd_avioes, qtd_pistas, qtd_fingers, qtd_bombas):
@@ -139,5 +138,3 @@ def configura_aeroporto(env, aeroporto, tempo_spawn, qtd_avioes, qtd_pistas, qtd
         yield env.timeout(random.randint(tempo_spawn-2, tempo_spawn+2))
         i += 1
         env.process(aviaoProc(env, 'Avião %d' % i, aeroporto))
-
-    pass

--- a/src/metricas.py
+++ b/src/metricas.py
@@ -117,5 +117,3 @@ def log_simulacao(data):
     tempo_medio_fila_pistas(data, qtd_avioes)
     tempo_medio_fila_finges(data, qtd_avioes)
     tempo_medio_fila_bomba(data)
-
-    pass


### PR DESCRIPTION
## Summary
- clean up leftover `pass` statements in airport modules

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685017badd58833080d9bcf674869cf5