### PR TITLE
Remove redundant pass and global statements

### DIFF
--- a/src/aeroporto.py
+++ b/src/aeroporto.py
@@ -31,7 +31,6 @@ class Aeroporto:
 
         # setup para iniciar filas
         self.init_queue(qtd_pistas, qtd_fingers, qtd_bombas)
-        pass
 
     def init_queue(self, qtd_pistas, qtd_fingers, qtd_bombas):
         for i in range(qtd_pistas):
@@ -43,35 +42,26 @@ class Aeroporto:
         for i in range(qtd_bombas):
             self.bomba.put({'id': i})
 
-        pass
 
     def registrar_metrica(self, entry):
         self.log_metricas.append(entry)
-        pass
 
     def procedimento(self, aviao, proc):
-        global VERBOSE_SERV
-
         tempo = 0
         if proc == 'pousar':
-            global TEMPO_POUSO
             tempo = TEMPO_POUSO
 
         elif proc == 'abastecer':
-            global TEMPO_ABASTECIMENTO
             tempo = TEMPO_ABASTECIMENTO
 
         elif proc == 'embarcar':
-            global TEMPO_EMBARQUE_DESEMBARQUE
             tempo = TEMPO_EMBARQUE_DESEMBARQUE
 
         elif proc == 'decolar':
-            global TEMPO_DECOLAGEM
             tempo = TEMPO_DECOLAGEM
 
         yield self.env.timeout(tempo)
         if VERBOSE_SERV:
             print('Avião %s em procedimento de %s.' % (aviao, proc))
-        pass
 
-    pass
+

--- a/src/aviao.py
+++ b/src/aviao.py
@@ -29,9 +29,7 @@ def aviaoProc(env, nome, aeroporto):
         'bomba de combustivel': None,
     }
 
-    global LOG_VERBOSE
-
-# ---------------- Pouso ----------------
+    # ---------------- Pouso ----------------
     # FILA
     if LOG_VERBOSE:
         print('%s em primeiro contato com o aeroporto às %.2f. Aguardando autorização de pouso.' % (
@@ -120,15 +118,10 @@ def aviaoProc(env, nome, aeroporto):
 
     # Registrar métricas
     aeroporto.registrar_metrica(log_simulacao)
-    pass
 
 
 def configura_aeroporto(env, aeroporto, tempo_spawn, qtd_avioes, qtd_pistas, qtd_fingers, qtd_bombas):
 
-    global TEMPO_POUSO
-    global TEMPO_EMBARQUE_DESEMBARQUE
-    global TEMPO_ABASTECIMENTO
-    global TEMPO_DECOLAGEM
 
     # cria os aviões iniciais
     for i in range(qtd_avioes):
@@ -139,5 +132,3 @@ def configura_aeroporto(env, aeroporto, tempo_spawn, qtd_avioes, qtd_pistas, qtd
         yield env.timeout(random.randint(tempo_spawn-2, tempo_spawn+2))
         i += 1
         env.process(aviaoProc(env, 'Avião %d' % i, aeroporto))
-
-    pass


### PR DESCRIPTION
## Summary
- clean unused `pass` statements from `aeroporto` and `aviao`
- remove unnecessary `global` declarations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685019798f488330bb281d8fa406d216